### PR TITLE
circleci support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: python:3.6
+    steps:
+      - checkout
+      - run: echo "run my tests!"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - locale
+            - .tx
+  transifex:
+    docker:
+      - image: python:2.7
+    steps:
+      - attach_workspace:
+          at: txci
+      - run: pip install transifex-client
+      - run: cd txci && tx push --source -l en --no-interactive
+workflows:
+  version: 2
+  my-ci-flow:
+    jobs:
+      - test
+      - transifex:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
Add support for CircleCI 2.0 using workflows.

The theory is your build runs using a different environment than what we
need for transifex-client (which is the `python:2.7` docker image).
Then, if the build is successful we run the `transifex` job which syncs
with transifex if we're on the `master` branch.
